### PR TITLE
refactor(database): renamed owner to resource_owner and position to global_position

### DIFF
--- a/internal/database/event.go
+++ b/internal/database/event.go
@@ -13,10 +13,10 @@ type Event struct {
 	AggregateSequence int64          `db:"aggregate_sequence" json:"aggregate_sequence"`
 	EventType         string         `db:"event_type" json:"event_type"`
 	Data              []byte         `db:"data" json:"data"`
-	Owner             sql.NullString `db:"owner" json:"owner"`
 	Creator           sql.NullString `db:"creator" json:"creator"`
+	ResourceOwner     sql.NullString `db:"resource_owner" json:"resource_owner"`
 	CorrelationId     sql.NullString `db:"correlation_id" json:"correlation_id"`
 	CausationId       sql.NullString `db:"causation_id" json:"causation_id"`
-	Position          float64        `db:"position" json:"position"`
+	GlobalPosition    float64        `db:"global_position" json:"global_position"`
 	CreatedAt         time.Time      `db:"created_at" json:"created_at"`
 }


### PR DESCRIPTION
# Changes

- [refactor(database): renamed owner to resource_owner and position to global_position](https://github.com/driftbase/auth/commit/e6a2079fe2ffe930a17db3d079d3829ea8cb464c)
	- reason: changed field names because they clash with internal postgres reserved names